### PR TITLE
Added ability to label backported PRs.

### DIFF
--- a/backport/Program.cs
+++ b/backport/Program.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Builder;
 using System.CommandLine.Parsing;
+using System.Diagnostics.Metrics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -15,18 +18,13 @@ namespace Backport
 {
     internal class Program
     {
-        /// <summary>
-        /// Avalonia Backport
-        /// </summary>
-        /// <param name="token">The OAUTH token, with public_repo permission.</param>
-        /// <param name="repository">The path to the Avalonia repository. Default: current directory</param>
-        /// <param name="candidates">The label from which backport candidates are selected.</param>
-        /// <param name="after">Skip until after this PR number</param>
+        private static ProductHeaderValue s_productInformation = new ProductHeaderValue("AvaloniaBackport", "0.0.1");
+
         static async Task<int> Main(string[] args)
         {
             var tokenOption = new Option<string>(
                 name: "--token",
-                description: "The OAUTH token, with public_repo permission.")
+                description: "The OAUTH token.")
                 {
                     Arity = ArgumentArity.ExactlyOne,
                 };
@@ -34,11 +32,15 @@ namespace Backport
             var repositoryOption = new Option<DirectoryInfo>(
                 "--repository",
                 () => new DirectoryInfo(Directory.GetCurrentDirectory()),
-                "The path to the Avalonia repository. Default: current directory");
+                "The path to the Avalonia repository.");
 
             var candidatesOption = new Option<string>(
                 "--candidates",
-                "The label from which backport candidates are selected.");
+                "The label from which backport candidates are selected. [default: calculated from release branch name]");
+
+            var backportedOption = new Option<string>(
+                "--backported",
+                "The label with which backported PRs are tagged. [default: calculated from release branch name]");
 
             var afterOption = new Option<int?>(
                 "--after",
@@ -49,6 +51,18 @@ namespace Backport
                 tokenOption,
                 repositoryOption,
                 candidatesOption,
+                backportedOption,
+                afterOption,
+            };
+
+            backportCommand.AddAlias("cherry-pick");
+
+            var labelCommand = new Command("label", "Label backported PRs")
+            {
+                tokenOption,
+                repositoryOption,
+                candidatesOption,
+                backportedOption,
                 afterOption,
             };
 
@@ -57,94 +71,68 @@ namespace Backport
             var rootCommand = new RootCommand("Avalonia Backport")
             {
                 backportCommand,
+                labelCommand,
             };
 
             backportCommand.SetHandler(
-                async (token, repository, candidates, after) =>
+                async (token, repository, candidates, backported, after) =>
                 {
-                    await Backport(token, repository, candidates, after);
+                    await Backport(token, repository, candidates, backported, after);
                 }, 
-                tokenOption, repositoryOption, candidatesOption, afterOption);
+                tokenOption, repositoryOption, candidatesOption, backportedOption, afterOption);
 
-            return await rootCommand.InvokeAsync(args);
+            labelCommand.SetHandler(
+                async (token, repository, candidates, backported, after) =>
+                {
+                    await LabelBackported(token, repository, candidates, backported, after);
+                },
+                tokenOption, repositoryOption, candidatesOption, backportedOption, afterOption);
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseDefaults()
+                .UseExceptionHandler((e, context) =>
+                {
+                    if (e is UserCancelledException)
+                    {
+                        Console.Write("\nUser cancelled.");
+                        context.ExitCode = 2;
+                    }
+                    else
+                    {
+                        Console.Write("\nError: ");
+                        Console.WriteLine(e.Message);
+                        context.ExitCode = 1;
+                    }
+                })
+                .Build();
+
+            return await parser.InvokeAsync(args);
         }
 
-        private static async Task<int> Backport(string token, DirectoryInfo repository, string candidates, int? after)
+        private static async Task Backport(string token, DirectoryInfo repository, string candidates, string backported, int? after)
         {
-            var productInformation = new ProductHeaderValue("AvaloniaBackport", "0.0.1");
-            var connection = new Connection(productInformation, token);
-            Repository repo;
-            Signature signature;
+            var connection = new Connection(s_productInformation, token);
+            var repo = new Repository(repository.FullName);
+            var signature = repo.Config.BuildSignature(DateTimeOffset.Now);
 
-            repository ??= new DirectoryInfo(Directory.GetCurrentDirectory());
+            GetDefaultLabels(repo, ref candidates, ref backported);
 
-            try
-            {
-                repo = new Repository(repository.FullName);
-                signature = repo.Config.BuildSignature(DateTimeOffset.Now);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-                return 1;
-            }
+            var pullRequests = await GetBackportCandidates(connection, candidates, backported, after);
 
-            if (string.IsNullOrWhiteSpace(candidates))
-            {
-                var releaseBranchRegex = new Regex("^release/(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$");
-                var match = releaseBranchRegex.Match(repo.Head.FriendlyName);
+            Console.WriteLine($"{pullRequests.Count} PRs to backport:\n");
 
-                if (!match.Success)
-                {
-                    Console.WriteLine($"Error: no label supplied and current branch ({repo.Head.FriendlyName}) is not a release branch.");
-                    return 1;
-                }
-
-                candidates = $"backport-candidate-{match.Groups[1].Value}.{match.Groups[2].Value}.x";
-                Console.WriteLine($"Label calculated as '{candidates}' from current branch '{repo.Head.FriendlyName}'.");
-            }
-
-            Console.WriteLine($"Reading pull requests with label {candidates}...");
-
-            var query = new Query()
-                .Repository("Avalonia", "AvaloniaUI")
-                .PullRequests(labels: new[] { candidates }, states: new[] { PullRequestState.Merged })
-                .AllPages()
-                .Select(pr => new
-                {
-                    pr.Number,
-                    pr.Title,
-                    Labels = pr.Labels(100, null, null, null, null).Select(x => x.Nodes).Select(x => x.Name).ToList(),
-                    MergeCommit = pr.MergeCommit.Select(x => x.Oid).Single(),
-                    pr.MergedAt,
-                })
-                .Compile();
-
-            var toMerge = (await connection.Run(query))
-                .Where(x => !x.Labels.Contains("wont-backport") && !x.Labels.Any(x => x.StartsWith("backported")))
-                .OrderBy(x => x.MergedAt)
-                .SkipWhile(x => after.HasValue && x.Number != after.Value)
-                .Skip(after.HasValue ? 1 : 0)
-                .ToList();
-
-            Console.WriteLine($"{toMerge.Count} PRs to backport:\n");
-
-            foreach (var pr in toMerge)
+            foreach (var pr in pullRequests)
             {
                 Console.WriteLine($"#{pr.Number} {pr.Title}");
             }
 
-            Console.WriteLine($"\n{toMerge.Count} PRs will be merged into branch '{repo.Head.FriendlyName}' of '{repository.FullName}'");
+            Console.WriteLine($"\n{pullRequests.Count} PRs will be merged into branch '{repo.Head.FriendlyName}' of '{repository.FullName}'");
             Console.WriteLine($"Signature: {signature}.");
             Console.WriteLine("Press Y to continue, any other key to abort.");
 
-            if (!Confirm())
-            {
-                Console.WriteLine("\nUser cancelled.");
-                return 2;
-            }
+            Confirm();
 
-            foreach (var pr in toMerge)
+            foreach (var pr in pullRequests)
             {
                 Console.WriteLine($"Merging #{pr.Number} {pr.Title} - {pr.MergeCommit}");
                 var commit = repo.Lookup<Commit>(pr.MergeCommit);
@@ -165,12 +153,7 @@ namespace Backport
                     if (result.Status == CherryPickStatus.Conflicts)
                     {
                         Console.WriteLine("CONFLICT. Fix the conflict and press Y to continue, any other key to abort");
-
-                        if (!Confirm())
-                        {
-                            Console.WriteLine("\nUser cancelled.");
-                            return 2;
-                        }
+                        Confirm();
 
                         // We need to refresh the repository here by reading the status, otherwise libgit2 thinks
                         // that we have uncommitted changes.
@@ -184,15 +167,181 @@ namespace Backport
             }
 
             Console.WriteLine("SUCCESS! Backport finished.");
-            return 0;
         }
 
-        private static bool Confirm()
+        private static async Task LabelBackported(string token, DirectoryInfo repository, string candidates, string backported, int? after)
+        {
+            var connection = new Connection(s_productInformation, token);
+            var repo = new Repository(repository.FullName);
+
+            GetDefaultLabels(repo, ref candidates, ref backported);
+
+            var candidateId = await GetLabelId(connection, candidates);
+            var backportedId = await GetLabelId(connection, backported);
+            var pullRequests = await GetBackportCandidates(connection, candidates, backported, after);
+            var cherryPicked = new List<Candidate>();
+            var notCherryPicked = new List<Candidate>();
+
+            Console.WriteLine($"{pullRequests.Count} PRs to check...\n");
+
+            foreach (var pr in ((IEnumerable<Candidate>)pullRequests).Reverse())
+            {
+                if (!pr.MergedAt.HasValue)
+                    Console.WriteLine($"Skipped #{pr.Number} as it has no timestamp.");
+
+                Console.WriteLine($"Checking #{pr.Number} {pr.Title} - {pr.MergeCommit}");
+
+                var mergeCommit = repo.Lookup<Commit>(pr.MergeCommit);
+                var mergeCommitTitle = mergeCommit.Message.Split('\n')[0];
+                var found = false;
+
+                foreach (var commit in repo.Commits)
+                {
+                    if (commit.Message.StartsWith(mergeCommitTitle) ||
+                        commit.Message.StartsWith($"Merge pull request #{pr.Number}"))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (found)
+                    cherryPicked.Add(pr);
+                else
+                    notCherryPicked.Add(pr);
+            }
+
+            Console.WriteLine($"\nCould not find a backport commit for {notCherryPicked.Count} PRs:\n");
+
+            foreach (var i in notCherryPicked)
+            {
+                Console.WriteLine($"#{i.Number} {i.Title}");
+            }
+
+            Console.WriteLine($"\n{cherryPicked.Count} PRs can be marked as backported:\n");
+
+            foreach (var i in cherryPicked)
+            {
+                Console.WriteLine($"#{i.Number} {i.Title}");
+            }
+
+            Console.WriteLine($"\n{cherryPicked.Count} PRs will be labelled with '{backported}' and have the '{candidates}' label removed.");
+            Console.WriteLine("Press Y to continue, any other key to abort.");
+
+            Confirm();
+
+            foreach (var pr in cherryPicked)
+            {
+                Console.WriteLine($"Labelling #{pr.Number}");
+
+                var query = new Mutation()
+                    .Select(m => new
+                    {
+                        m1 = m.AddLabelsToLabelable(new AddLabelsToLabelableInput
+                        {
+                            LabelableId = pr.Id,
+                            LabelIds = new[] { backportedId },
+                        }).Select(x => x.ClientMutationId).Single(),
+                        m2 = m.RemoveLabelsFromLabelable(new RemoveLabelsFromLabelableInput
+                        {
+                            LabelableId = pr.Id,
+                            LabelIds = new[] { candidateId },
+                        }).Select(x => x.ClientMutationId).Single(),
+                    })
+                    .Compile();
+                await connection.Run(query);
+            }
+        }
+
+        private static void Confirm()
         {
             var key = Console.ReadKey();
-            var result = key.KeyChar == 'Y' || key.KeyChar == 'y';
             Console.WriteLine();
-            return result;
+            if (key.KeyChar == 'Y' || key.KeyChar == 'y')
+                return;
+            throw new UserCancelledException();
         }
+
+        private static async Task<List<Candidate>> GetBackportCandidates(
+            Connection connection, 
+            string candidates, 
+            string backported,
+            int? after)
+        {
+            Console.WriteLine($"Reading pull requests with label {candidates}...");
+
+            var query = new Query()
+                .Repository("Avalonia", "AvaloniaUI")
+                .PullRequests(labels: new[] { candidates }, states: new[] { PullRequestState.Merged })
+                .AllPages()
+                .Select(pr => new Candidate(
+                    pr.Id,
+                    pr.Number,
+                    pr.Title,
+                    pr.Labels(100, null, null, null, null).Select(x => x.Nodes).Select(x => x.Name).ToList(),
+                    pr.MergeCommit.Select(x => x.Oid).Single(),
+                    pr.MergedAt
+                ))
+                .Compile();
+
+            return (await connection.Run(query))
+                .Where(x => !x.Labels.Contains("wont-backport") && !x.Labels.Contains(backported))
+                .OrderBy(x => x.MergedAt)
+                .SkipWhile(x => after.HasValue && x.Number != after.Value)
+                .Skip(after.HasValue ? 1 : 0)
+                .ToList();
+        }
+
+        private static void GetDefaultLabels(Repository repo, ref string candidates, ref string backported)
+        {
+            if (!string.IsNullOrWhiteSpace(candidates) && !string.IsNullOrWhiteSpace(backported))
+                return;
+
+            var (major, minor) = GetVersionFromBranch(repo.Head.FriendlyName, "--candidates");
+
+            if (string.IsNullOrWhiteSpace(candidates))
+            {
+                candidates = $"backport-candidate-{major}.{minor}.x";
+                Console.WriteLine($"Backport candidate label calculated as '{candidates}' from current branch '{repo.Head.FriendlyName}'.");
+            }
+
+            if (string.IsNullOrWhiteSpace(backported))
+            {
+                backported = $"backported-{major}.{minor}.x";
+                Console.WriteLine($"Backported label calculated as '{backported}' from current branch '{repo.Head.FriendlyName}'.");
+            }
+        }
+
+        private static async Task<ID> GetLabelId(Connection connection, string name)
+        {
+            var query = new Query()
+                .Repository("Avalonia", "AvaloniaUI")
+                .Label(name)
+                .Select(x => x.Id)
+                .Compile();
+            var id = await connection.Run(query);
+
+            if (id.Value is null)
+                throw new ArgumentException($"Label '{name}' not found.");
+
+            return id;
+        }
+
+        private static (int major, int minor) GetVersionFromBranch(string branch, string option)
+        {
+            var releaseBranchRegex = new Regex("^release/(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$");
+            var match = releaseBranchRegex.Match(branch);
+
+            if (match.Success &&
+                int.TryParse(match.Groups[1].Value, out var major) &&
+                int.TryParse(match.Groups[2].Value, out var minor))
+            {
+                return (major, minor);
+            }
+
+            throw new ArgumentException($"Current branch '{branch}' is not a release branch. Specify the --candidates and --backported labels explicitly.");
+        }
+
+        private record Candidate(ID Id, int Number, string Title, List<string> Labels, string MergeCommit, DateTimeOffset? MergedAt);
     }
 }

--- a/backport/backport.csproj
+++ b/backport/backport.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Backport</RootNamespace>
 	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
-    <PackageReference Include="Octokit.GraphQL" Version="0.1.7-beta" />
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="Octokit.GraphQL" Version="0.2.1-beta" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
   </ItemGroup>
 
 </Project>

--- a/backport/backport.csproj
+++ b/backport/backport.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
     <PackageReference Include="Octokit.GraphQL" Version="0.2.1-beta" />
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Refactored to use separate commands: we now have "cherrypick" and "label"
- Make "label" command label backported PRs.